### PR TITLE
X509 multi domain certificates support

### DIFF
--- a/gui/views/cert.py
+++ b/gui/views/cert.py
@@ -273,8 +273,8 @@ def load(request):
         # if cert.cn is empty check if subjectAltName is set en use it
         if(not cert.cn):
             alt_name=x509Cert.get_ext('subjectAltName').get_value()
-        if(alt_name):
-            cert.cn=alt_name
+            if(alt_name):
+              cert.cn=alt_name
 
         cert.save()
 

--- a/gui/views/cert.py
+++ b/gui/views/cert.py
@@ -270,6 +270,12 @@ def load(request):
             elif str(tmp[0]) == "OU":
                 cert.ou = tmp[1]
 
+        # if cert.cn is empty check if subjectAltName is set en use it
+        if(not cert.cn):
+            alt_name=x509Cert.get_ext('subjectAltName').get_value()
+        if(alt_name):
+            cert.cn=alt_name
+
         cert.save()
 
         return HttpResponseRedirect('/system/cert/')


### PR DESCRIPTION
Add support for multi domain X509 certificates that do not have CN but many subjectAltName instead.

If CN field is empty, we will check sujectAltName and use it to display it on GUI.